### PR TITLE
PHP 7.2 to 7.4 Testing with Guzzle 7.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-8.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-9.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-9.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ install:
 - composer install --no-interaction
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION > '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   # Force PHPUnit 7 #2693
 - php -v
 - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-6.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ php:
 - 7.1
 - 7.2
 - 7.3
+- 7.4
+- 8.0
 install:
 - composer install --no-interaction
 - if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ install:
   # Force PHPUnit 7 #2693
 - php -v
 - phpunit --version
+before_script:
+ # Disable the HHVM JIT for faster Unit Testing
+- if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
+- if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then test -z "$DISABLE_FUNCTIONS" || echo "disable_functions=$DISABLE_FUNCTIONS" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi  
 before_deploy:
 - php ./bin/build.php
 - export RELEASE_PKG_FILE=$(ls build/*zip)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-10.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-9.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-9.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-6.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,10 @@ install:
 - composer install --no-interaction
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   # Force PHPUnit 7 #2693
 - php -v
 - phpunit --version
-before_script:
- # Disable the HHVM JIT for faster Unit Testing
-- if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
-- if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then test -z "$DISABLE_FUNCTIONS" || echo "disable_functions=$DISABLE_FUNCTIONS" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi  
+
 before_deploy:
 - php ./bin/build.php
 - export RELEASE_PKG_FILE=$(ls build/*zip)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-8.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-10.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 - 7.3
 install:
 - composer install --no-interaction
-- if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
   # Force PHPUnit 7 #2693
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-6.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v
 - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ php:
 - 7.3
 install:
 - composer install --no-interaction
+- if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+  # Force PHPUnit 7 #2693
+- php -v
+- phpunit --version
 before_deploy:
 - php ./bin/build.php
 - export RELEASE_PKG_FILE=$(ls build/*zip)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ install:
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
 - if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-8.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
   # Force PHPUnit 7 #2693
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,10 @@ install:
 - composer install --no-interaction
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
-- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
+- if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
   # Force PHPUnit 7 #2693
 - php -v
 - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ install:
 - composer install --no-interaction
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O $COMPOSER_BIN_DIR/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
-- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 $COMPOSER_BIN_DIR/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O $COMPOSER_BIN_DIR/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 $COMPOSER_BIN_DIR/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O $COMPOSER_BIN_DIR/phpunit https://phar.phpunit.de/phpunit-8.phar; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 $COMPOSER_BIN_DIR/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-8.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
   # Force PHPUnit 7 #2693
 - php -v
 - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ install:
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
 - if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
   # Force PHPUnit 7 #2693

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
 - 5.6
 - 7.0
 - 7.1
+- 7.2
+- 7.3
 install:
 - composer install --no-interaction
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ install:
 - if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
 - if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   # Force PHPUnit Upgrade for relevant PHP Versions
-- if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v
 - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-6.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
 - 7.2
 - 7.3
 - 7.4
-- 8.0
 install:
 - composer install --no-interaction
 - if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
@@ -14,11 +13,9 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-9.phar; fi
-- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-
 - php -v
 - phpunit --version
+- vendor/bin/phpunit --version
 
 before_deploy:
 - php ./bin/build.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,12 @@ install:
 - composer install --no-interaction
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
-- if [[ $TRAVIS_PHP_VERSION > '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-8.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   # Force PHPUnit 7 #2693
 - php -v
 - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-6.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ install:
 - composer install --no-interaction
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
-- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-8.phar; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O $COMPOSER_BIN_DIR/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 $COMPOSER_BIN_DIR/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O $COMPOSER_BIN_DIR/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 $COMPOSER_BIN_DIR/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O $COMPOSER_BIN_DIR/phpunit https://phar.phpunit.de/phpunit-8.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 $COMPOSER_BIN_DIR/phpunit; fi
   # Force PHPUnit 7 #2693
 - php -v
 - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ install:
 - composer install --no-interaction
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   # Force PHPUnit 7 #2693
 - php -v
 - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ install:
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
 - if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
   # Force PHPUnit 7 #2693

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-8.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ install:
 - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
 - if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
   # Force PHPUnit 7 #2693
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ install:
 - if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
 - if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   # Force PHPUnit Upgrade for relevant PHP Versions
-- if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION <= '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION <= '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION >= '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
-- if [[ $TRAVIS_PHP_VERSION >= '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v
 - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-9.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,12 @@ php:
 - 7.3
 install:
 - composer install --no-interaction
-- if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then wget -O ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; fi
-- if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then chmod 755 ~/.phpenv/versions/hhvm/bin/phpunit; fi
 - if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
 - if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+  # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-  # Force PHPUnit 7 #2693
+
 - php -v
 - phpunit --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-- 5.5
 - 5.6
 - 7.0
 - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Force PHPUnit Upgrade for relevant PHP Versions
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
 - if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.5' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-8.phar; fi
 - if [[ $TRAVIS_PHP_VERSION = '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ install:
 - if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-4.phar; fi
 - if [[ $TRAVIS_PHP_VERSION < '7.2' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
   # Force PHPUnit Upgrade for relevant PHP Versions
-- if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION < '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-6.phar; fi
-- if [[ $TRAVIS_PHP_VERSION > '7.3' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION <= '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar; fi
+- if [[ $TRAVIS_PHP_VERSION > '7.1' && $TRAVIS_PHP_VERSION <= '7.4' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
+- if [[ $TRAVIS_PHP_VERSION >= '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then wget -O vendor/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
+- if [[ $TRAVIS_PHP_VERSION >= '8.0' || $TRAVIS_PHP_VERSION = nightly ]]; then chmod 755 vendor/bin/phpunit; fi
 
 - php -v
 - phpunit --version

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # InterFAX PHP Library
 
-[![PHP version](https://badge.fury.io/ph/interfax%2Finterfax.svg)](https://badge.fury.io/ph/interfax%2Finterfax)[![Build status](https://travis-ci.org/interfax/interfax-php.svg?branch=master)](https://travis-ci.org/interfax/interfax-php)
+[![PHP version](https://badge.fury.io/ph/interfax%2Finterfax.svg)](https://badge.fury.io/ph/interfax%2Finterfax)[![Build status](https://travis-ci.org/ricky-shake-n-bake-bobby/interfax-php.svg?branch=master)](https://travis-ci.org/ricky-shake-n-bake-bobby/interfax-php)
 
 [Installation](#installation) | [Getting Started](#getting-started) | [Contributing](#contributing) | [Usage](#usage) | [License](#license)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # InterFAX PHP Library
 
-[![PHP version](https://badge.fury.io/ph/interfax%2Finterfax.svg)](https://badge.fury.io/ph/interfax%2Finterfax)[![Build status](https://travis-ci.com/ricky-shake-n-bake-bobby/interfax-php.svg?branch=master)](https://travis-ci.com/ricky-shake-n-bake-bobby/interfax-php)
+[![PHP version](https://badge.fury.io/ph/interfax%2Finterfax.svg)](https://badge.fury.io/ph/interfax%2Finterfax)[![Build status](https://travis-ci.com/interfax/interfax-php.svg?branch=master)](https://travis-ci.com/interfax/interfax-php)
 
 [Installation](#installation) | [Getting Started](#getting-started) | [Contributing](#contributing) | [Usage](#usage) | [License](#license)
 
@@ -8,7 +8,7 @@ Send and receive faxes in PHP with the [InterFAX](https://www.interfax.net/en/de
 
 ## Installation
 
-This library requires PHP 5.5 and above. You may use any of the following 3 approaches to add it to your project:
+This library requires PHP 5.6 and above. You may use any of the following 3 approaches to add it to your project:
 
 ### Composer
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # InterFAX PHP Library
 
-[![PHP version](https://badge.fury.io/ph/interfax%2Finterfax.svg)](https://badge.fury.io/ph/interfax%2Finterfax)[![Build status](https://travis-ci.org/ricky-shake-n-bake-bobby/interfax-php.svg?branch=master)](https://travis-ci.org/ricky-shake-n-bake-bobby/interfax-php)
+[![PHP version](https://badge.fury.io/ph/interfax%2Finterfax.svg)](https://badge.fury.io/ph/interfax%2Finterfax)[![Build status](https://travis-ci.com/ricky-shake-n-bake-bobby/interfax-php.svg?branch=master)](https://travis-ci.com/ricky-shake-n-bake-bobby/interfax-php)
 
 [Installation](#installation) | [Getting Started](#getting-started) | [Contributing](#contributing) | [Usage](#usage) | [License](#license)
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^8.0",
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^7.0",
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.8|^7.0"
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "mikey179/vfsstream": "^1.6",
+        "bovigo/vfsStream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^7.0"
+        "phpunit/phpunit": "^4.8|^7.0",
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.8",
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^7.5",
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Send and receive faxes with InterFAX",
     "type": "library",
     "require": {
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "bovigo/vfsStream": "^1.6",
+        "bovigo/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^8.0",
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "bovigo/vfsstream": "^1.6",
+        "mikey179/vfsstream": "^1.6.8",
         "squizlabs/php_codesniffer": "^2.7"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,11 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0.0",
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
+    },
+    "suggest": {
+        "phpunit/phpunit": "Allows automated tests to be run without system-wide install (only version 4-7 are supported)."
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^4.8",
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "mikey179/vfsstream": "^1.6.8",
+        "mikey179/vfsstream": "^1.6.7",
         "squizlabs/php_codesniffer": "^2.7"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.0.0",
         "mikey179/vfsstream": "^1.6",
         "squizlabs/php_codesniffer": "^2.7"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -24,11 +24,11 @@
             "require": {
                 "guzzlehttp/promises": "^1.0",
                 "guzzlehttp/psr7": "^1.3.1",
-                "php": ">=5.5"
+                "php": ">=5.6"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
+                "phpunit/phpunit": "^5.0",
                 "psr/log": "^1.0"
             },
             "type": "library",

--- a/composer.lock
+++ b/composer.lock
@@ -492,7 +492,7 @@
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
+                "php": "^5.3|^7.0|^8.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "sebastian/comparator": "^1.1",
                 "sebastian/recursion-context": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -286,7 +286,7 @@
         },
         {
             "name": "mikey179/vfsStream",
-            "version": "v1.6.4",
+            "version": "v1.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mikey179/vfsStream.git",

--- a/composer.lock
+++ b/composer.lock
@@ -783,16 +783,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.27",
+            "version": "4.8.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
                 "shasum": ""
             },
             "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -245,7 +245,7 @@
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": ">=5.3,<=8.0.3"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -1040,7 +1040,7 @@
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8 || ^5.0"

--- a/composer.lock
+++ b/composer.lock
@@ -290,12 +290,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mikey179/vfsStream.git",
-                "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592"
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/0247f57b2245e8ad2e689d7cee754b45fbabd592",
-                "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592",
+                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
                 "shasum": ""
             },
             "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -478,7 +478,7 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "v1.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",

--- a/composer.lock
+++ b/composer.lock
@@ -232,7 +232,7 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",

--- a/composer.lock
+++ b/composer.lock
@@ -1423,7 +1423,7 @@
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3|^7.0|^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
 
     <testsuites>


### PR DESCRIPTION
Added version specific testing for PHP Versions 7.2-7.4 + Guzzle 7 Support.  Remove PHP 5.5 Testing as no longer supported by Travis Ci.